### PR TITLE
feat: enhance strikethrough styling for DONE blocks

### DIFF
--- a/packages/django-app/app/knowledge/static/knowledge/css/app.css
+++ b/packages/django-app/app/knowledge/static/knowledge/css/app.css
@@ -573,12 +573,26 @@ body {
 
 .block-content.completed {
   text-decoration: line-through;
-  opacity: 0.7;
+  text-decoration-color: #00ff00;
+  text-decoration-thickness: 2px;
+  opacity: 0.6;
+  color: #009900;
 }
 
 .block-content-display.completed {
   text-decoration: line-through;
-  opacity: 0.7;
+  text-decoration-color: #00ff00;
+  text-decoration-thickness: 2px;
+  opacity: 0.6;
+  color: #009900;
+}
+
+/* Additional styling for better visual hierarchy of completed blocks */
+.block-item .block-content.completed,
+.block-item .block-content-display.completed {
+  text-decoration: line-through !important;
+  text-decoration-color: #00ff00 !important;
+  text-decoration-thickness: 2px !important;
 }
 
 .block-delete {


### PR DESCRIPTION
Enhances the visual styling of completed DONE blocks in the knowledge management system.

## Changes
- Add bright green strikethrough color (00ff00) matching app theme
- Increase strikethrough thickness to 2px for better visibility
- Adjust completed text color to darker green (00990)
- Improve opacity to 0.6 for better readability
- Add higher specificity CSS rules to prevent overrides

Closes #4

Generated with [Claude Code](https://claude.ai/code)