### PR TITLE
Fix README setup reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ The initial MVP focuses on:
 
 ## Development Setup
 
-See the `docs/` folder for detailed development instructions and setup guides.
+See `.ai/PROJECT_SETUP.md` for detailed development instructions and setup guides.


### PR DESCRIPTION
## Summary
- point setup instructions to `.ai/PROJECT_SETUP.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685b33f5306c8322ab3884544e0b718e